### PR TITLE
NuGet publish

### DIFF
--- a/.github/workflows/nugetpublish.yml
+++ b/.github/workflows/nugetpublish.yml
@@ -26,4 +26,4 @@ jobs:
       run: nuget pack NHtmlUnit.nuspec
 
     - name: Publish To NuGet.org
-      run: nuget push *.nupkg -Source nuget.org -ApiKey ${{ secrets.NuGet_APIKey }}
+      run: nuget push *.nupkg -Source nuget.org -ApiKey ${{ secrets.NUGET_API_KEY }}

--- a/NHtmlUnit.nuspec
+++ b/NHtmlUnit.nuspec
@@ -6,15 +6,15 @@
     <title>NHtmlUnit</title>
     <authors>OKB AS</authors>
     <owners>OKB AS</owners>
-    <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
+	<license type="expression">Apache-2.0</license>
     <projectUrl>https://github.com/HtmlUnit/NHtmlUnit</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>NHtmlUnit is a .NET wrapper of HtmlUnit; a "GUI-less browser for Java programs". It allows you to write code to test web applications with a headless, automated browser.</description>
-    <releaseNotes>Updated to version 7.4.5196 of IKVM.</releaseNotes>
+    <releaseNotes>Updated to HtmlUnit 2.50</releaseNotes>
     <copyright>Copyright © OKB AS 2021</copyright>
     <tags>testing htmlunit nhtmlunit headless browser</tags>
     <dependencies>
-        <dependency id="IKVM" version="7.4.5196.0" />
+		<dependency id="IKVM" version="8.1.5717" />
     </dependencies>
     <frameworkAssemblies />
     <references />

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ NHtmlUnit was written by @asbjornu and @beewarloc.
 [6]: https://travis-ci.org/HtmlUnit/NHtmlUnit
 [7]: https://img.shields.io/appveyor/ci/HtmlUnit/NHtmlUnit/master.svg
 [8]: https://ci.appveyor.com/project/HtmlUnit/NHtmlUnit/branch/master
-[9]: https://www.codefactor.io/repository/github/htmlunit/nhtmlunit/badge/master
-[10]: https://www.codefactor.io/repository/github/htmlunit/nhtmlunit/overview/master
+[9]: https://www.codefactor.io/repository/github/htmlunit/nhtmlunit/badge
+[10]: https://www.codefactor.io/repository/github/htmlunit/nhtmlunit
 [11]: https://github.com/HtmlUnit/NHtmlUnit/actions/workflows/unittests.yml/badge.svg
 [12]: https://github.com/HtmlUnit/NHtmlUnit/actions/workflows/unittests.yml
 [htmlunit]: http://htmlunit.sourceforge.net/


### PR DESCRIPTION
1. Manual Trigger of workflow (see Actions -> Nuget Publish)
2. All ready to go, **but** before you try to publish you need to setup the APIKey secret so you can publish to nuget:
  2a: In Nuget.org -> your name (top right) > API Keys -> Create new key and copy
  2b: In GitHub -> NHtmlUnit -> Settings -> Secrets (only visible to Contributors) -> Add a new secret called "NUGET_APIKEY" with the APIKey as value

Resolves #38.